### PR TITLE
Project name

### DIFF
--- a/bin/rudy
+++ b/bin/rudy
@@ -42,6 +42,7 @@ class RudyCLI < Rudy::CLI::Base
   global :t, :testrun, "Test run. Don't execute action (PARTIALLY SUPPORTED)."
   global :P, :parallel, "Execute remote commands in parallel (PARTIALLY SUPPORTED)."
   global :F, :force, "Force an action despite warnings"
+  global :p, :project, String, "Project name. Used in group and machine names."
 
   global :positions, Integer, "Override positions number for the current role"
   

--- a/lib/rudy.rb
+++ b/lib/rudy.rb
@@ -56,7 +56,7 @@ module Rudy
   end
   def sysinfo; Rudy.sysinfo;  end
     
-  unless defined? Rudy::DOMAIN # We can assume all constants are defined
+  unless defined? Rudy::DEFAULT_DOMAIN # We can assume all constants are defined
     
     @@quiet = false
     @@auto = false

--- a/lib/rudy.rb
+++ b/lib/rudy.rb
@@ -65,7 +65,7 @@ module Rudy
     
     # SimpleDB accepts dashes in the domain name on creation and with the query syntax. 
     # However, with select syntax it says: "The specified query expression syntax is not valid"
-    DOMAIN = "rudy_state".freeze
+    DEFAULT_DOMAIN = "rudy_state".freeze
     DELIM  = '-'.freeze
   
     CONFIG_DIR = File.join(Rudy.sysinfo.home, '.rudy').freeze

--- a/lib/rudy/cli/machines.rb
+++ b/lib/rudy/cli/machines.rb
@@ -1,5 +1,4 @@
 
-
 module Rudy
   module CLI
     class Machines < Rudy::CLI::CommandBase

--- a/lib/rudy/global.rb
+++ b/lib/rudy/global.rb
@@ -43,6 +43,7 @@ module Rudy
     field :bucket
 
     field :positions
+    field :project
     
     
     attr_accessor :print_header
@@ -73,7 +74,7 @@ module Rudy
         # value from the defaults config. 
         # WARNING: Don't add bucket either or any machines configuration param 
         # TODO: investigate removing this apply_config method
-        %w[region zone environment role position bucket
+        %w[region zone environment role position bucket project
            localhost nocolor quiet auto force parallel].each do |name|
           curval, defval = self.send(name), config.defaults.send(name)
           if curval.nil? && !defval.nil?

--- a/lib/rudy/huxtable.rb
+++ b/lib/rudy/huxtable.rb
@@ -168,7 +168,7 @@ module Rudy
     
     
     def current_machine_group
-      [@@global.environment, @@global.role].join(Rudy::DELIM)
+      [@@global.project, @@global.environment, @@global.role].compact.join(Rudy::DELIM)
     end
     
     def current_group_name

--- a/lib/rudy/huxtable.rb
+++ b/lib/rudy/huxtable.rb
@@ -48,16 +48,16 @@ module Rudy
     
     def self.create_domain
       @sdb = Rudy::AWS::SDB.new(@@global.accesskey, @@global.secretkey, @@global.region)
-      @sdb.create_domain Rudy::DOMAIN
+      @sdb.create_domain Rudy::DEFAULT_DOMAIN
     end
     
     def self.domain_exists?
       @sdb = Rudy::AWS::SDB.new(@@global.accesskey, @@global.secretkey, @@global.region)
-      (@sdb.list_domains || []).member? Rudy::DOMAIN
+      (@sdb.list_domains || []).member? Rudy::DEFAULT_DOMAIN
     end
     
     def self.domain
-      Rudy::DOMAIN
+      Rudy::DEFAULT_DOMAIN
     end
     
     # Puts +msg+ to +@@logger+

--- a/lib/rudy/huxtable.rb
+++ b/lib/rudy/huxtable.rb
@@ -48,16 +48,17 @@ module Rudy
     
     def self.create_domain
       @sdb = Rudy::AWS::SDB.new(@@global.accesskey, @@global.secretkey, @@global.region)
-      @sdb.create_domain Rudy::DEFAULT_DOMAIN
+      @sdb.create_domain self.domain
     end
     
     def self.domain_exists?
       @sdb = Rudy::AWS::SDB.new(@@global.accesskey, @@global.secretkey, @@global.region)
-      (@sdb.list_domains || []).member? Rudy::DEFAULT_DOMAIN
+      (@sdb.list_domains || []).member? self.domain
     end
     
     def self.domain
-      Rudy::DEFAULT_DOMAIN
+      name = @@global.project.to_s.gsub(/\W/, '_').downcase
+      [name, Rudy::DEFAULT_DOMAIN].join('_')
     end
     
     # Puts +msg+ to +@@logger+

--- a/lib/rudy/metadata.rb
+++ b/lib/rudy/metadata.rb
@@ -7,7 +7,7 @@ module Rudy
     COMMON_FIELDS = [:region, :zone, :environment, :role].freeze
     
     @@rsdb   = nil
-    @@domain = Rudy::DEFAULT_DOMAIN
+    @@domain = Rudy::Huxtable.domain
     
     #
     def self.get_rclass(rtype)

--- a/lib/rudy/metadata.rb
+++ b/lib/rudy/metadata.rb
@@ -7,7 +7,7 @@ module Rudy
     COMMON_FIELDS = [:region, :zone, :environment, :role].freeze
     
     @@rsdb   = nil
-    @@domain = Rudy::DOMAIN
+    @@domain = Rudy::DEFAULT_DOMAIN
     
     #
     def self.get_rclass(rtype)
@@ -45,11 +45,11 @@ module Rudy
       @@domain = n if @@rsdb.create_domain n
     end
     
-    # Destroys a SimpleDB domain named +n+ and sets +@@domain+ to Rudy::DOMAIN
+    # Destroys a SimpleDB domain named +n+ and sets +@@domain+ to Rudy::DEFAULT_DOMAIN
     def self.destroy_domain(n)
       Rudy::Huxtable.ld "DESTROY: #{n}" if Rudy.debug?
       @@rsdb.destroy_domain n
-      @@domain = Rudy::DOMAIN
+      @@domain = Rudy::DEFAULT_DOMAIN
       true
     end
     

--- a/lib/rudy/metadata.rb
+++ b/lib/rudy/metadata.rb
@@ -4,7 +4,7 @@ module Rudy
   module Metadata
     include Rudy::Huxtable
     
-    COMMON_FIELDS = [:region, :zone, :environment, :role].freeze
+    COMMON_FIELDS = [:region, :zone, :project, :environment, :role].freeze
     
     @@rsdb   = nil
     @@domain = Rudy::Huxtable.domain
@@ -182,8 +182,8 @@ module Rudy
     end
     
     def name(*other)
-      parts = [@rtype, @zone, @environment, @role, @position, *other].flatten
-      parts.join Rudy::DELIM
+      parts = [@rtype, @zone, @project, @environment, @role, @position, *other]
+      parts.compact.flatten.join Rudy::DELIM
     end
     
     def save(replace=false)

--- a/tryouts/30_metadata/10_include_tryouts.rb
+++ b/tryouts/30_metadata/10_include_tryouts.rb
@@ -12,7 +12,7 @@ tryouts "include Rudy::Metadata" do
     Rudy::Huxtable.global.offline = false
   end
   
-  drill "has default domain", Rudy::DOMAIN do
+  drill "has default domain", Rudy::DEFAULT_DOMAIN do
     Rudy::Metadata.domain
   end
   
@@ -28,7 +28,7 @@ tryouts "include Rudy::Metadata" do
   
   dream test_domain
   drill "can create test domain (automatically sets new internal domain)" do
-    Rudy::Metadata.domain = Rudy::DOMAIN
+    Rudy::Metadata.domain = Rudy::DEFAULT_DOMAIN
     Rudy::Metadata.create_domain test_domain
   end
   

--- a/tryouts/30_metadata/50_disk_tryouts.rb
+++ b/tryouts/30_metadata/50_disk_tryouts.rb
@@ -4,7 +4,7 @@ library :rudy, 'lib'
 
 tryout "Disk API" do
   
-  set :test_domain, Rudy::DOMAIN #'test_' << Rudy::Utils.strand(4)
+  set :test_domain, Rudy::DEFAULT_DOMAIN #'test_' << Rudy::Utils.strand(4)
   set :test_env, 'stage' #'env_' << Rudy::Utils.strand(4)
   
   setup do

--- a/tryouts/30_metadata/60_backup_tryouts.rb
+++ b/tryouts/30_metadata/60_backup_tryouts.rb
@@ -5,7 +5,7 @@ library :rudy, 'lib'
 tryout "Backup API" do
   
   set :sample_time, Time.now.utc
-  set :test_domain, Rudy::DOMAIN #'test_' << Rudy::Utils.strand(4)
+  set :test_domain, Rudy::DEFAULT_DOMAIN #'test_' << Rudy::Utils.strand(4)
   set :test_env, :stage #'env_' << Rudy::Utils.strand(4)
   
   setup do

--- a/tryouts/30_metadata/66_backup_snapshot_tryouts.rb
+++ b/tryouts/30_metadata/66_backup_snapshot_tryouts.rb
@@ -5,7 +5,7 @@ library :rudy, 'lib'
 tryout "Backup Snapshot API" do
   
   set :sample_time, Time.now.utc
-  set :test_domain, Rudy::DOMAIN #'test_' << Rudy::Utils.strand(4)
+  set :test_domain, Rudy::DEFAULT_DOMAIN #'test_' << Rudy::Utils.strand(4)
   set :test_env, :stage #'env_' << Rudy::Utils.strand(4)
   
   setup do

--- a/tryouts/30_metadata/70_machine_tryouts.rb
+++ b/tryouts/30_metadata/70_machine_tryouts.rb
@@ -4,7 +4,7 @@ group "Metadata"
 
 tryout "Rudy::Machine API" do
   
-  set :test_domain, Rudy::DOMAIN #'test_' << Rudy::Utils.strand(4)
+  set :test_domain, Rudy::DEFAULT_DOMAIN #'test_' << Rudy::Utils.strand(4)
   set :test_env, 'stage' #'env_' << Rudy::Utils.strand(4)
 
   setup do

--- a/tryouts/30_metadata/76_machine_instance_tryouts.rb
+++ b/tryouts/30_metadata/76_machine_instance_tryouts.rb
@@ -4,7 +4,7 @@ group "Metadata"
 
 tryout "Rudy::Machine Instance API" do
   
-  set :test_domain, Rudy::DOMAIN #'test_' << Rudy::Utils.strand(4)
+  set :test_domain, Rudy::DEFAULT_DOMAIN #'test_' << Rudy::Utils.strand(4)
   set :test_env, 'stage' #'env_' << Rudy::Utils.strand(4)
 
   setup do

--- a/tryouts/30_metadata/77_machines_tryouts.rb
+++ b/tryouts/30_metadata/77_machines_tryouts.rb
@@ -5,7 +5,7 @@ group "Metadata"
 
 tryout "Rudy::Machines API" do
   
-  set :test_domain, Rudy::DOMAIN #'test_' << Rudy::Utils.strand(4)
+  set :test_domain, Rudy::DEFAULT_DOMAIN #'test_' << Rudy::Utils.strand(4)
   set :test_env, 'stage' #'env_' << Rudy::Utils.strand(4)
 
   setup do


### PR DESCRIPTION
Hey Delano,

Here is the first stab at a pull request to add a project name to Rudy.  Some notes:
1. I created a `-p` project command line global, which you can use or you can define `project 'name'` in your `defaults` block in your `Rudyfile`.
2. I changed all the instances of `Rudy::DOMAIN` to `Rudy::DEFAULT_DOMAIN`, as well as centralize all notion of what the domain is for the current Rudy project to `Rudy::Huxtable.domain`.  This centralized domain takes in to account the project name (if specified).
3. I changed the machine group name and metadata name to include the project name, if specified.
4. As you requested, I made things backwards compatible so if you do not specify a project name, all the generated domains, groups and metadata names are the exact same as they are before this patch.

Please let me know if this all looks good and if you have any additional feedback.  Once it does, I'll add some examples in `examples/` and you can merge this pull request.
