### PR TITLE
Project name updates

### DIFF
--- a/bin/rudy
+++ b/bin/rudy
@@ -238,6 +238,7 @@ class RudyCLI < Rudy::CLI::Base
   command :init do |obj|
     
     Rudy::Huxtable.update_config
+    Rudy::Huxtable.update_global obj.global # Pull in any command line globals
     
     unless File.exists? Rudy::CONFIG_FILE
       Rudy::Config.init_config_dir

--- a/bin/rudy
+++ b/bin/rudy
@@ -42,7 +42,7 @@ class RudyCLI < Rudy::CLI::Base
   global :t, :testrun, "Test run. Don't execute action (PARTIALLY SUPPORTED)."
   global :P, :parallel, "Execute remote commands in parallel (PARTIALLY SUPPORTED)."
   global :F, :force, "Force an action despite warnings"
-  global :p, :project, String, "Project name. Used in group and machine names."
+  global :N, :project, String, "Project name. Used in group and machine names."
 
   global :positions, Integer, "Override positions number for the current role"
   

--- a/lib/rudy/huxtable.rb
+++ b/lib/rudy/huxtable.rb
@@ -58,7 +58,7 @@ module Rudy
     
     def self.domain
       name = @@global.project.to_s.gsub(/\W/, '_').downcase
-      [name, Rudy::DEFAULT_DOMAIN].join('_')
+      [name, Rudy::DEFAULT_DOMAIN].reject(&:empty?).join('_')
     end
     
     # Puts +msg+ to +@@logger+


### PR DESCRIPTION
Added 3 more things.
1. Fixed a bug where empty project names were causing domains to be prefixed by `_` in `Huxtable.domain`.
2. Updated the Huxtable config from the command line globals on init to pick up `--project` passed in from the command line.
3. Changed short option for `--project` to `-N`, per our discussion.
