### PR TITLE
Spot cleanup

### DIFF
--- a/lib/rudy/aws/ec2/spot_request.rb
+++ b/lib/rudy/aws/ec2/spot_request.rb
@@ -89,6 +89,11 @@ module Rudy::AWS
           end
         end
       end
+      
+      def cancel(requests)
+        opts = requests ? {:spot_instance_request_id => requests.map(&:id)} : {}
+        Rudy::AWS::EC2.execute_request({}) { @@ec2.cancel_spot_instance_requests(opts) }
+      end
 
       private
 

--- a/lib/rudy/exceptions.rb
+++ b/lib/rudy/exceptions.rb
@@ -68,5 +68,7 @@ module Rudy
   
   class NotImplemented < Rudy::Error; end
   
+  class SpotRequestCancelled < Rudy::Error; end
+  
   
 end

--- a/lib/rudy/metadata.rb
+++ b/lib/rudy/metadata.rb
@@ -182,7 +182,7 @@ module Rudy
     end
     
     def name(*other)
-      project = (@project && @project.first.empty?) ? nil : @project
+      project = (@project.is_a?(Array) && @project.first.empty?) ? nil : @project
       parts = [@rtype, @zone, project, @environment, @role, @position, *other]
       parts.compact.flatten.join Rudy::DELIM
     end

--- a/lib/rudy/metadata.rb
+++ b/lib/rudy/metadata.rb
@@ -88,6 +88,9 @@ module Rudy
     # Generates a default criteria for all metadata based on
     # region, zone, environment, and role. If a position has
     # been specified in the globals it will also be included.
+    # The project name will also be removed if empty, to
+    # maintain backwards compatability with metadata entries
+    # that do not contain a projet field.
     # * +rtype+ is the record type. One of: m, disk, or back.
     # * +fields+ replaces and adds values to this criteria
     # * +less+ removes keys from the default criteria. 
@@ -102,6 +105,7 @@ module Rudy
       mixer = names.zip(values).flatten
       criteria = Hash[*mixer].merge(fields)
       criteria.reject! { |n,v| less.member?(n) }
+      criteria.delete(:project) if criteria[:project].to_s.empty?
       Rudy::Huxtable.ld "CRITERIA: #{criteria.inspect}"
       criteria
     end

--- a/lib/rudy/metadata.rb
+++ b/lib/rudy/metadata.rb
@@ -182,7 +182,8 @@ module Rudy
     end
     
     def name(*other)
-      parts = [@rtype, @zone, @project, @environment, @role, @position, *other]
+      project = (@project && @project.first.empty?) ? nil : @project
+      parts = [@rtype, @zone, project, @environment, @role, @position, *other]
       parts.compact.flatten.join Rudy::DELIM
     end
     

--- a/lib/rudy/routines/handlers/spot_request.rb
+++ b/lib/rudy/routines/handlers/spot_request.rb
@@ -21,6 +21,9 @@ module Rudy; module Routines; module Handlers;
       request = Rudy::AWS::EC2::SpotRequests.create(opts)
       raise NoMachines unless wait_for_fulfillment_of(request)
       Rudy::AWS::EC2::SpotRequests.list(request)
+    rescue NoMachines
+      Rudy::AWS::EC2::SpotRequests.cancel(request)
+      raise SpotRequestCancelled
     end
 
     def wait_for_fulfillment_of(spot_requests)


### PR DESCRIPTION
More bug fixes:
1. Fixed extra `--` in metadata names of machines when no project is specified.
2. Spot requests are cancelled at EC2 when the user gives up waiting for them to be fulfilled.

I'd probably leave this pull request open until we figure out the size/AZ config bug from the other pull request.  That way, if we need to, I can add it as more commits to this pull request before you merge it in to master.
